### PR TITLE
[ENC] getting rid of type- key

### DIFF
--- a/src/05-derivatives/02-common-data-types.md
+++ b/src/05-derivatives/02-common-data-types.md
@@ -22,9 +22,7 @@ data types in the specification. Examples:
 
 -   Motion-corrected DWI files.
 
-The `space` keyword denotes reference atlas or map that the File is
-aligned to - see [Introduction](01-introduction.md) for allowed values. The
-`desc` keyword is a general purpose field with freeform values. To distinguish
+The `space` keyword is recomended to distinguish files with different underlying coordinate systems or registered to different reference maps. The `desc` keyword is a general purpose field with freeform values. To distinguish
 between multiple different versions of processing for the same input data the
 `desc` keyword should be used. Note that even though `space` and `desc`
 are optional at least one of them needs to be defined to avoid name conflict
@@ -74,7 +72,7 @@ Template:
 <pipeline_name>/
     sub-<participant_label>/
         func|anat|dwi/
-        <source_keywords>[_space-<space>][_type-<type>][_desc-<label>]_mask.nii.gz
+        <source_keywords>[_space-<space>][_desc-<label>]_mask.nii.gz
 ```
 
 A binary (1 - inside, 0 - outside) mask in the space defined by `<space>`.


### PR DESCRIPTION
I don't know where the type key came from. 
I also tried to remove the reference to a space table in the introduction that has moved (is it in the appendix?)

(I'll post this an issue)
So currently we have. _dseg.tsv suffix for color lookup tables. A label-<label> key value pair for specifying the label in _probseg.nii.gz files. And files with multiple mask (i.e. atlases having a _dseg.nii.gz) extension. And and atlas-<label> key value pair that appears in fmri..

1. is it ok for _dseg.nii.gz and _dseg.tsc to have the same suffix? or are suffixes supposed to associate with a specific file type.
2. technically the _dparc.dlabel.nii could be _dseg.dlabel.nii because they have similar concepts (just cifti vs nifti).
3.